### PR TITLE
Select only a elements with '#comment' in their href

### DIFF
--- a/features.user.js
+++ b/features.user.js
@@ -880,7 +880,7 @@ var functionsToCall = { //ALL the functions must go in here
     
     showCommentScores: function () { //For adding a button on your profile comment history pages to show your comment's scores
         var sitename = SEHelper.getSiteName('api');
-        $('.history-table td b a').each(function() {
+        $('.history-table td b a[href*="#comment"]').each(function() {
             id = $(this).attr('href').split('#')[1].split('_')[0].replace('comment', '');
             $(this).after("<span class='showCommentScore' id='"+id+"'>&nbsp;&nbsp;&nbsp;show comment score</span>");
         });    


### PR DESCRIPTION
Show Comment Score was failing when things that weren't comments appeared alongside comments in the list (e.g., revisions) because many of these did not have a "#" in their url, which led to an undefined error breaking things.

I made the selector check for "#comment" inside the url to fix this.
